### PR TITLE
protobuf requirement for tensorflow compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy==1.19.5
 pandas==1.1.5
+protobuf==3.20.*
 scikit_learn==1.2.2
 scipy==1.5.4
 tensorflow==2.6.2


### PR DESCRIPTION
With a fresh Python 3.9 environment on my machine, the tensorflow package in requirements.txt fails to install due to a protobuf dependency. This change resolved the problem on my end.