### PR TITLE
Logging

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -95,7 +95,7 @@ def read_config_file(args, hp_default_dict):
         hp_default_dict (dict): default hyperparameter settings
     """
 
-    with open(args.config_path, mode="r") as file:
+    with open(args.config_path, mode="rt", encoding='utf-8') as file:
         cfg_dict = yaml.safe_load(file)
     for key, val in cfg_dict.items():
         if key in args:


### PR DESCRIPTION
1. Logging of test dataset is made possible by ensuring that the model is evaluated once per epoch, or every n epochs. This is controlled by a new argument called "--eval_freq" (default=1).
2. The model state dictionary (state_dict) was being saved to file every 1000 batches, when there were typically ~1200 batches per epoch. Now, it is logged once per epoch, on the last batch. Test mode does not save the state dict.
3. The model state dict was being saved anew for each epoch. A new CLI argument is added to allow changing behavior to overwrite the state dict every epoch. This is called  "--overwrite_save" and defaults to False.
4. To facilitate plotting, the training data is saved to a CSV-formatted file, in addition to the usual log.