### PR TITLE
Address problems in official code

### DIFF
--- a/model.py
+++ b/model.py
@@ -72,7 +72,6 @@ class GraphLayer(nn.Module):
                 nn.Dropout(dropout),
                 LayerNorm(hidden_features),
                 nn.ELU()
-                # linear is not present here in official code (should it be?)
             )
         else:
             self.ffn = nn.Sequential(
@@ -173,7 +172,7 @@ class VariationalGNN(nn.Module):
     """
 
     def __init__(self, in_features, out_features, num_of_nodes, n_heads, n_layers,
-                 dropout, alpha, variational=True, excluded_features=0):
+                 dropout, alpha, variational=True, excluded_features=0, mask_prob=0):
         super(VariationalGNN, self).__init__()
         self.variational = variational
         self.num_of_nodes = num_of_nodes + 1 - excluded_features
@@ -181,6 +180,7 @@ class VariationalGNN(nn.Module):
         self.n_heads = n_heads
         self.dropout = nn.Dropout(dropout)
         self.excluded_features = excluded_features
+        self.mask_prob = mask_prob
 
         # Encoder
         self.embed = nn.Embedding(self.num_of_nodes, in_features, padding_idx=0)
@@ -189,13 +189,12 @@ class VariationalGNN(nn.Module):
                        n_heads, dropout, alpha, concat=True),
             n_layers)
         
-        # Decoder
-        self.out_att = GraphLayer(in_features, in_features, out_features, self.num_of_nodes,
-                                  n_heads, dropout, alpha, concat=False)
-        
         # Variational regularization
         self.parameterize = nn.Linear(out_features, out_features * 2)
 
+        # Decoder
+        self.out_att = GraphLayer(in_features, in_features, out_features, self.num_of_nodes,
+                                  n_heads, dropout, alpha, concat=False)
         decoder_output_size = out_features
         if excluded_features > 0:
             decoder_output_size = out_features + out_features // 2
@@ -247,7 +246,6 @@ class VariationalGNN(nn.Module):
         Returns:
             (torch.Tensor, torch.Tensor): input and output graph connectivity in COO format
         """
-        mask_prob = 0.05
         n = codes.size()[0]
         observed = codes.nonzero() # observed EHR codes, of shape (num_nonzero, 1)
         if observed.size()[0] == 0:
@@ -255,7 +253,7 @@ class VariationalGNN(nn.Module):
         if self.training:
             # Exclude observed codes with 0.05 probability
             mask = torch.rand(observed.size()[0])
-            mask = mask > mask_prob
+            mask = mask > self.mask_prob
             observed = observed[mask]
             if observed.size()[0] == 0:
                 return torch.LongTensor([[0], [0]]), torch.LongTensor([[n + 1], [n + 1]])

--- a/train.py
+++ b/train.py
@@ -50,6 +50,8 @@ hp_default_dict = {
                         'help': 'upsample scale factor for training data'},
     'excluded_features': {'type': int, 'default': 0,
                         'help': 'number of features to exclude from graph during training'},
+    'mask_prob': {'type': float, 'default': 0.05,
+                  'help': 'probability of masking nodes of graph during training'},
     'num_of_epochs': {'type': int, 'default': 50, 'help': 'number of epochs to train'},
     'save_model': {'type': str_to_bool, 'default': 'True',
                    'help': 'whether to save the model parameters to file once per epoch'},
@@ -72,8 +74,6 @@ def main():
     out_features = args.embedding_size
 
     gradient_max_norm = 5 # clip gradient to prevent exploding gradient
-    # In eICU data, the first feature, whether the patient has been admitted before,
-    # is not included in the graph
     
     # Load data and upsample training data
     train_x, train_y = None, None
@@ -116,7 +116,8 @@ def main():
     model = VariationalGNN(in_features, out_features, num_of_nodes, args.num_of_heads,
                            args.num_of_layers - 1, dropout=args.dropout,
                            alpha=args.leaky_relu_alpha, variational=args.reg,
-                           excluded_features=args.excluded_features).to(device)
+                           excluded_features=args.excluded_features, mask_prob=args.mask_prob
+                           ).to(device)
     model = nn.DataParallel(model, device_ids=device_ids)
     val_loader = DataLoader(dataset=EHRData(val_x, val_y), batch_size=args.batch_size,
                             collate_fn=collate_fn, num_workers=torch.cuda.device_count(),


### PR DESCRIPTION
Problems and inefficiencies identified during the refactor are corrected here. This model will not produce the exact same output as the main branch, given the same seed. However, these changes should improve model performance and make the code easier to understand.

Summary:
* Removed FFN in GraphLayer that was never being used.
* Initialize attention weights in decoder (out_att).
* Made node masking probability variable and added to CLI. Official code has this set at 0.05 probability, but paper lists 0.1 probability. Defaults to 0.05.
* GraphLayer layers are declared in the order in which they are applied.
* The final FFN of GraphLayer, out_layer, is no longer declared and redefined.
* In VGNN forward, merge two independent for loops over batch.