### PR TITLE
Add regularization methods

### DIFF
--- a/train.py
+++ b/train.py
@@ -18,8 +18,8 @@ import torch.nn as nn
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from model import VariationalGNN
-from utils import (collate_fn, EHRData, evaluate, read_config_file,
+from model import VariationalGNN, Regularized
+from utils import (collate_fn, EHRData, evaluate, read_config_file, str_choice,
                    str_to_bool, train, write_config_file)
 
 
@@ -30,6 +30,7 @@ print('Using device:', device)
 if device.type == 'cuda':
     print(torch.cuda.get_device_name(0))
     
+reg_options = ['l2', 'l1', 'none']
 hp_default_dict = {
     'config_path': {'type': str, 'help': 'load parameters from file'},
     'result_path': {'type': str, 'default': '.', 'help': 'output path of model checkpoints'},
@@ -41,9 +42,13 @@ hp_default_dict = {
     'lr': {'type': float, 'default': 1e-4, 'help': 'initial learning rate'},
     'batch_size': {'type': int, 'default': 32, 'help': 'batch size'},
     'dropout': {'type': float, 'default': 0.4, 'help': 'dropout rate'},
-    'reg': {'type': str_to_bool, 'default': 'True',
+    'var': {'type': str_to_bool, 'default': 'True',
             'help': 'apply variational regularization'},
-    'kl_scale': {'type': float, 'default': 1.0, 'help': 'scaling of KL divergence'},
+    'var_scale': {'type': float, 'default': 1.0,
+                 'help': 'scaling of KL divergence term if using variational regularization'},
+    'reg_method': {'type': lambda x: str_choice(x, reg_options), 'default':'l2',
+                   'help': f'regularization method. options: {reg_options}'},
+    'reg_weight': {'type': float, 'default': 1e-8, 'help': 'weight of regularization term'},
     'leaky_relu_alpha': {'type': float, 'default': 0.1,
                          'help': 'angle of negative slope in LeakyReLU function'},
     'upsample_factor': {'type': int, 'default': 2,
@@ -53,6 +58,8 @@ hp_default_dict = {
     'mask_prob': {'type': float, 'default': 0.05,
                   'help': 'probability of masking nodes of graph during training'},
     'num_of_epochs': {'type': int, 'default': 50, 'help': 'number of epochs to train'},
+    'weight_decay': {'type': float, 'default': 0,
+                     'help': 'optimizer weight decay'},
     'save_model': {'type': str_to_bool, 'default': 'True',
                    'help': 'whether to save the model parameters to file once per epoch'},
     'overwrite_save': {'type': str_to_bool, 'default': 'False',
@@ -93,8 +100,10 @@ def main():
     val_x, val_y = pickle.load(open(args.data_path + 'validation_csr.pkl', 'rb'))
 
     # Configure logging
-    result_folder = (f'reg_{str(args.reg)}-lr_{args.lr}-dropout_{args.dropout}-'
-                     f'embedding_{in_features}-batch_size_{args.batch_size}')
+    model_name = f'VGNN_{args.var_scale}' if args.var else 'Enc-dec'
+    reg_name = '' if args.reg_method == 'none' else f'reg_{args.reg_method}_{args.reg_weight}'
+    result_folder = (f'{model_name}-{reg_name}-lr_{args.lr}-dropout_{args.dropout}-'
+                     f'embed_{in_features}-batch_{args.batch_size}')
     if args.test:
         result_folder += '-TEST'
     result_root = Path(args.result_path) / result_folder
@@ -119,15 +128,17 @@ def main():
     # eICU has 1 feature on previous readmission that we didn't include in the graph
     model = VariationalGNN(in_features, out_features, num_of_nodes, args.num_of_heads,
                            args.num_of_layers - 1, dropout=args.dropout,
-                           alpha=args.leaky_relu_alpha, variational=args.reg,
+                           alpha=args.leaky_relu_alpha, variational=args.var,
                            excluded_features=args.excluded_features, mask_prob=args.mask_prob
                            ).to(device)
+    if args.reg_method != 'none':
+        model = Regularized(model, args.reg_method, args.reg_weight)
     model = nn.DataParallel(model, device_ids=device_ids)
     val_loader = DataLoader(dataset=EHRData(val_x, val_y), batch_size=args.batch_size,
                             collate_fn=collate_fn, num_workers=torch.cuda.device_count(),
                             shuffle=False)
-    optimizer = optim.Adam([p for p in model.parameters() if p.requires_grad], lr=args.lr,
-                           weight_decay=1e-8)
+    optimizer = optim.AdamW([p for p in model.parameters() if p.requires_grad], lr=args.lr,
+                            weight_decay=args.weight_decay)
     scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=5, gamma=0.5)
 
     # Train models
@@ -153,7 +164,7 @@ def main():
         t = tqdm(iter(train_loader), leave=False, total=last_batch, unit='batch')
         for idx, batch_data in enumerate(t):
             # Train model on batch
-            loss, kld, bce = train(batch_data, model, optimizer, criterion, args.kl_scale,
+            loss, kld, bce = train(batch_data, model, optimizer, criterion, args.var_scale,
                                    gradient_max_norm)
             total_loss += np.array([loss, bce, kld])
             if idx > 0:

--- a/utils.py
+++ b/utils.py
@@ -4,8 +4,6 @@ Representation Learning for Electronic Health Records (cited)
 https://github.com/NYUMedML/GNN_for_EHR
 '''
 
-import argparse
-
 import numpy as np
 from sklearn.metrics import precision_recall_curve, auc
 import torch
@@ -21,7 +19,6 @@ print('Using device:', device)
 
 if device.type == 'cuda':
     print(torch.cuda.get_device_name(0))
-
 
 
 def train(data, model, optim, criterion, kl_scale, max_clip_norm=5):
@@ -159,3 +156,21 @@ def str_to_bool(input_str):
         print(msg + '\n')
         raise ValueError(msg)
     return input_str in pos
+
+def str_choice(input_str, options):
+    """Ensures input string is one of a set of valid choices.
+
+    Args:
+        input_str (str): input string
+        options (str): valid choices
+
+    Returns:
+        str: selection
+    """
+    input_str = input_str.lower()
+    options = [opt.lower() for opt in options]
+    if not input_str in options:
+        msg = f'Invalid argument. Argument must be one of these choices: {options}'
+        print(msg + '\n')
+        raise ValueError(msg)
+    return input_str


### PR DESCRIPTION
Introduces regularization methods that can be applied separately from variational regularization.

This breaks backwards compatibility because the official code uses the Adam optimizer and a non-zero weight decay, which itself applies L2 regularization. This also means that, even when variational regularization was being applied, L2 regularization was as well. We need the flexibility to activate variational and L2/L1/None regularation separately.

Instead of performing L2 regularization through the optimizer, a wrapper class is introduced in model.py to apply regularization by updating the gradient directly. This method is used for L1 regularization as well.

In order to keep some flexibility with weight decay in the optimizer, the method was changed from Adam to AdamW, allows for application of weight decay with affecting regularization.

CLI arguments are changed and introduced to support these changes.

Changed:
* reg -> var (default: true)
* kl_scal -> var_scale (default: 1.0)

New:
* reg_method: regularization method {'L2', 'L1', 'none} (default: 'L2')
* reg_weight: weight of regularization term
* weight_decay: AdamW weight decay value (default: 0)